### PR TITLE
Fix typo in undo-manager.md

### DIFF
--- a/docs/api/undo-manager.md
+++ b/docs/api/undo-manager.md
@@ -87,8 +87,8 @@ doc.transact(() => {
   ytext.insert(0, 'abc')
 }, 41)
 undoManager.undo()
-ytext.toString() // => '' (not tracked because 41 is not an instance of
-                 //        `trackedTransactionorigins`)
+ytext.toString() // => 'abc' (not tracked because 41 is not an instance of
+                 //           `trackedTransactionorigins`)
 ytext.delete(0, 3) // revert change
 
 doc.transact(() => {


### PR DESCRIPTION
I think this is a typo - running the code outputs the following sequence:

```
"abc"
""
"abc"
""
```